### PR TITLE
Login Fail Message is fixed

### DIFF
--- a/com-dict-client/src/store/actions/authActions.js
+++ b/com-dict-client/src/store/actions/authActions.js
@@ -7,6 +7,7 @@ export const signIn = (credentials) => async (firebase, history) => {
     history.goBack();
   } catch (e) {
     console.log(e.message);
+    message.error("There is no user record corresponding to this credentials.Please enter valid credentials")
   }
 };
 


### PR DESCRIPTION
Solves #52 

![LoginPopUpFixed](https://user-images.githubusercontent.com/39923784/106807864-a8021f80-668f-11eb-8085-378f7fb22a75.JPG)

Added a message to be shown when login credentials are not found in database which was missing earlier. 