### PR TITLE
Fix blank space in navbar

### DIFF
--- a/com-dict-client/src/components/Header/index.js
+++ b/com-dict-client/src/components/Header/index.js
@@ -70,7 +70,9 @@ function TitleBar() {
                 key="profile"
               >
                 <Menu.Item key="cat:0">
-                  <Link to="/#">{user.displayName}</Link>
+                  <Link to="/#">
+                    {user.displayName ? user.displayName : user.email}
+                  </Link>
                 </Menu.Item>
                 <Menu.Item key="cat:0">
                   <Typography onClick={() => signOut()(firebase, history)}>


### PR DESCRIPTION
Fixes #59 

When user signup through their email instead of google login ,user email will be shown in the navbar. If user signup through a social network their display name will be shown
![22222](https://user-images.githubusercontent.com/31257148/107264269-c9388680-6a68-11eb-8711-949e5cadff56.PNG)
