### PR TITLE
[IMPROVE] Move Test Modules into Dev Dependencies 

### DIFF
--- a/com-dict-client/package.json
+++ b/com-dict-client/package.json
@@ -3,14 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.5.0",
-    "@testing-library/user-event": "^7.2.1",
     "algoliasearch": "^4.3.1",
     "antd": "^4.2.5",
     "firebase": "^7.13.1",
     "firebase-functions": "^3.8.0",
-    "puppeteer": "^5.2.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-instantsearch-dom": "^6.7.0",
@@ -23,6 +19,12 @@
     "redux-auth-wrapper": "^3.0.0",
     "redux-firestore": "^0.13.0",
     "redux-thunk": "^2.3.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/react": "^9.5.0",
+    "@testing-library/user-event": "^7.2.1",
+    "puppeteer": "^5.2.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
### Changes

Test dependencies including `testing-library` and `puppeteer` could be moved into `devDependencies` of package.json.

This change makes it even clearer that *dependencies* are required for the main functioning of the app and *devDependencies* are required for building and testing the app.