### PR TITLE
fix: removing the gap above the logout button and displaying the email id of the user there

### DIFF
--- a/com-dict-client/package.json
+++ b/com-dict-client/package.json
@@ -8,7 +8,7 @@
     "@testing-library/user-event": "^7.2.1",
     "algoliasearch": "^4.3.1",
     "antd": "^4.2.5",
-    "firebase": "^7.13.1",
+    "firebase": "^7.24.0",
     "firebase-functions": "^3.8.0",
     "puppeteer": "^5.2.1",
     "react": "^16.13.1",

--- a/com-dict-client/src/components/Header/index.js
+++ b/com-dict-client/src/components/Header/index.js
@@ -70,7 +70,7 @@ function TitleBar() {
                 key="profile"
               >
                 <Menu.Item key="cat:0">
-                  <Link to="/#">{user.displayName}</Link>
+                  <Link to="/#">{user.email}</Link>
                 </Menu.Item>
                 <Menu.Item key="cat:0">
                   <Typography onClick={() => signOut()(firebase, history)}>


### PR DESCRIPTION
There was a gap above the logout button . I have used that portion for displaying the email id of the user .
Error:
![Screenshot 2023-03-08 19 43 16](https://user-images.githubusercontent.com/107420267/223738079-d1f26499-5f79-40b0-aba6-b06ec88ff168.png)
Fix:
![Screenshot 2023-03-08 19 46 54](https://user-images.githubusercontent.com/107420267/223738137-449cd30c-bf80-4358-b7aa-fdb97f5bb54a.png)
