### PR TITLE
Feature: option to add word as word of the day

### DIFF
--- a/com-dict-client/package.json
+++ b/com-dict-client/package.json
@@ -12,6 +12,7 @@
     "firebase-functions": "^3.8.0",
     "puppeteer": "^5.2.1",
     "react": "^16.13.1",
+    "react-calendar": "^4.0.0",
     "react-dom": "^16.13.1",
     "react-instantsearch-dom": "^6.7.0",
     "react-redux": "^7.2.0",

--- a/com-dict-client/src/components/AddWord/index.js
+++ b/com-dict-client/src/components/AddWord/index.js
@@ -11,6 +11,9 @@ import {
   message,
 } from "antd";
 import WordClass from "./WordClass";
+
+import Calendar from "react-calendar";
+import "react-calendar/dist/Calendar.css";
 import EditableTagGroup from "./RelatedWords";
 
 import { useFirestore, useFirestoreConnect } from "react-redux-firebase";
@@ -45,6 +48,13 @@ function WordForm() {
   const onSubmit = (values) => {
     // const definition = values;
     // console.log(definition);
+    var dateString = null;
+    if (checked) {
+      dateString = new Date(date.getTime() - date.getTimezoneOffset() * 60000)
+        .toISOString()
+        .split("T")[0];
+    }
+
     const data = {
       other_language: language,
       head_term: headTerm,
@@ -60,13 +70,16 @@ function WordForm() {
       uname: user.displayName,
       createdAt: new Date().getTime(),
       alphabatical: headTerm[0].toUpperCase(),
-      word_of_the_day: null,
+      word_of_the_day: dateString,
       pronunciation: null,
       trending_factor: 0,
     };
     console.log(data);
     return addWord(data)(firestore);
   };
+
+  const [date, setDate] = useState(new Date());
+  const [checked, setChecked] = React.useState(false);
 
   const categories = useSelector((state) => state.firestore.ordered.categories);
 
@@ -87,7 +100,9 @@ function WordForm() {
     console.log(newHdTm);
     addHeadTerm(newHdTm)(firestore, setHeadTerm);
   };
-
+  const handleChange = () => {
+    setChecked(!checked);
+  };
   return (
     <div>
       <Row>
@@ -244,6 +259,27 @@ function WordForm() {
                 <Row>
                   <Col xl={6} ls={6} md={3} sm={0} xs={0}></Col>
                   <Col xl={12} lg={12} md={18} sm={24} xs={24}>
+                    <div>
+                      <label>
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={handleChange}
+                        />
+                        Word of the Day?
+                      </label>
+                    </div>
+                    {checked && (
+                      <div className="app">
+                        <h1 className="header">Select Date</h1>
+                        <div className="calendar-container">
+                          <Calendar onChange={setDate} value={date} />
+                        </div>
+                        <div className="text-center">
+                          Selected date: {date.toDateString()}
+                        </div>
+                      </div>
+                    )}
                     <Button
                       type="primary"
                       // size="large"

--- a/com-dict-client/src/components/WordHome/index.js
+++ b/com-dict-client/src/components/WordHome/index.js
@@ -26,7 +26,7 @@ function WordHome() {
           // let lastItem = "";
           const defs = [];
           querySnapshot.docs.filter((doc) => {
-            if (doc.data().word_of_the_day) {
+            if (Date.parse(doc.data().word_of_the_day)<Date.parse(moment().format("YYYY-MM-DD"))) {
               // lastItem = doc.id;
               let tempObj = {};
               tempObj = doc.data();


### PR DESCRIPTION
Feature Added

**This feature will help the editor to add words as well as give the option to select the day on which this word should appear as word of the Day.**

Earlier While adding a new word
![image](https://user-images.githubusercontent.com/93936630/224619319-06819c95-2c17-44ae-a5dc-e89a976fee2f.png)

Now, I have added the option to choose whether to add this word as Word of the Day and if yes, the user can select the date from the Calendar.
![image](https://user-images.githubusercontent.com/93936630/224619897-0b9c1f5e-1976-4555-8a62-094a6048c67c.png)

The word will appear on the home page on the selected day
![image](https://user-images.githubusercontent.com/93936630/224620337-efbe9dcc-7de4-4e4b-b789-4dfe16cf7c57.png)

and, after the day is passed then only it will appear here
![image](https://user-images.githubusercontent.com/93936630/224621456-9decb92d-5bb3-4aee-a6c9-ee4bf9a587a1.png)

And, if you have chosen a date which will come then it will not appear on the home page till the date but, you can browse it on the Dictionary page.
