### PR TITLE
refreshing the "Add Word" page, the user not redirected to a sign-up section

### DIFF
--- a/com-dict-client/src/routes.js
+++ b/com-dict-client/src/routes.js
@@ -21,9 +21,10 @@ export default function Routes() {
       <Route exact path="/browse" component={Browse} />
       <Route path="/search/:language/:keyword" component={Search} />
       <Route exact path="/Categories" component={Categories} />
-      <PrivateRoute path="/add">
+      <Route exact path="/add" component={AddWord} />
+      {/* <PrivateRoute path="/add">
         <AddWord />
-      </PrivateRoute>
+      </PrivateRoute> */}
       <Route path="/letter" component={LetterBased} />
       <Route path="/comment" component={CommentWord} />
       <Route path="/report" component={Report} />


### PR DESCRIPTION
**Issue:** #127 

When refreshing the page, user not redirected to signup section and stick on that page only when upto all the sections are not filled completely.

**Attaching Screenshot :**

![Screenshot (301)1](https://user-images.githubusercontent.com/82963534/227701807-08376a9a-84a7-45bd-a3a0-1c496040093c.png)
